### PR TITLE
発展課題

### DIFF
--- a/answer.md
+++ b/answer.md
@@ -1,0 +1,59 @@
+# 発展課題 
+
+## URLが20個並んだブログ記事を更新できるようにするためにはどうすればいいいか考えて実装してください  
+
+該当コミット: 
+https://github.com/SlashNephy/Hatena-Intern-2020/commit/b6261b0d00559e1826b4a90313163c6b316f7c1c
+
++ 数十個程度であれば, `renderer-ts` <-> `fetcher` の通信処理を並列化するだけで高速化できると考えた。  
+  + `fetcher` (grpc-kotlin) サーバは並列にリクエストを捌ける。
+  + `renderer-ts` では直列にリクエストを叩いている部分があったので, その呼び出し部分を改善した。  
++ 参考に 1 URL 取得に平均 700 ms 程度かかっていた。
+  + この実装にしたところ 20 URLs 取得しても 3 s 程度で済んだ。
+  + (従来の実装では 20 × 700 ms ...!)
+
+従来の実装 (抜粋)
+```typescript
+for (const node of updates) {
+    try {
+        const title = await getPageTitle(node.url) ?? node.url;
+    }
+    // ...
+}
+```
+
+改善した実装 (抜粋)
+```typescript
+const promises = updates.map(node => new Promise(async (resolve) => {
+    try {
+        const title = await getPageTitle(node.url) ?? node.url;
+        // ...
+    }
+    // ...
+}
+
+await Promise.all(promises);
+```
+
+
+## 100個、あるいは500個URLがあるときはどうすればいいでしょうか。
+
++ 数十個程度であれば, 上の実装を使えば改善できた。
++ しかし, gRPC サーバが一度に受け入れられるリクエスト数や, クライアント側で発行するリクエスト数の上限といった現実的な問題もある。
+  + そもそもサーバが応答しなくなれば, 元も子もない。
++ `renderer-ts` が記事の更新を非同期に行えばよいと思った。
+  + 現在の実装では, ユーザが記事の更新を行うと `renderer-ts` がレンダリングを終えるまで待たされてしまう。
+  + `renderer-ts` がユーザからの記事の更新リクエストを受け取ると, バックグラウンドでレンダリングを行う実装にすればユーザのストレスがなくなる。
++ この方法なら, 上の問題もカバーできる。
+
+
+## 一般に外部のウェブサイトへリクエストを行うサービスを設計する際に注意すべきことを考えましょう。ウェブサイト運営者の立場に立って、困ることを考えましょう。  
+### クローラーを実装するときにどのような対応策をとればよいでしょうか。
+
++ `User-Agent` ヘッダを適切に設定し, サービス運営者が必要に応じて連絡できるように配慮する。  
+
+該当コミット: https://github.com/SlashNephy/Hatena-Intern-2020/blob/auto-title-fetching/services/fetcher/src/main/kotlin/fetcher/FetcherHttpClient.kt#L11
+
++ `robots.txt` や `<meta name="robots">` タグを考慮する。  
+
++ リクエスト頻度や時間帯を配慮する。

--- a/services/fetcher/build.gradle.kts
+++ b/services/fetcher/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.google.protobuf.gradle.*
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.4.0"
@@ -82,7 +83,15 @@ kotlin {
         main {
             kotlin.srcDir(buildDir.resolve("generated/source/proto/main/grpckt"))
         }
+
+        all {
+            languageSettings.useExperimentalAnnotation("kotlin.time.ExperimentalTime")
+        }
     }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
 }
 
 java {

--- a/services/fetcher/src/main/kotlin/fetcher/Config.kt
+++ b/services/fetcher/src/main/kotlin/fetcher/Config.kt
@@ -11,5 +11,5 @@ object Config {
         } ?: Mode.Production
 
     val grpcPort: Int
-        get() = System.getProperty("GRPC_PORT")?.toIntOrNull() ?: 50052
+        get() = System.getenv("GRPC_PORT")?.toIntOrNull() ?: 50052
 }

--- a/services/fetcher/src/main/kotlin/fetcher/FetcherService.kt
+++ b/services/fetcher/src/main/kotlin/fetcher/FetcherService.kt
@@ -3,11 +3,31 @@ package fetcher
 import fetcher.pb.FetcherServiceGrpcKt
 import fetcher.pb.PageTitleRequest
 import fetcher.pb.PageTitleResponse
+import io.ktor.http.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+import kotlin.time.hours
+import kotlin.time.toJavaDuration
 
 object FetcherService: FetcherServiceGrpcKt.FetcherServiceCoroutineImplBase() {
     override suspend fun getPageTitle(request: PageTitleRequest): PageTitleResponse {
         val result = runCatching {
-            Http.getPageTitle(request.url)
+            when (val old = getPageTitleFromCache(request.url)) {
+                is PageTitleCache.Value -> {
+                    logger.info { "Found url in cache: ${request.url}" }
+
+                    old.value
+                }
+                is PageTitleCache.NotFound -> {
+                    logger.info { "Not found url in cache: ${request.url}" }
+
+                    val new = Http.getPageTitle(request.url)
+                    setPageTitleToCache(request.url, new)
+
+                    new
+                }
+            }
         }.onSuccess {
             logger.info { "gRPC response success: ${request.url} => $it" }
         }.onFailure {
@@ -28,5 +48,40 @@ object FetcherService: FetcherServiceGrpcKt.FetcherServiceCoroutineImplBase() {
                 }
             }
             .build()
+    }
+
+    private val cache = mutableMapOf<String, PageTitleCache.Value>()
+    private val cacheLock = Mutex()
+    private val cacheValidDuration = 3.hours.toJavaDuration()
+
+    private sealed class PageTitleCache {
+        data class Value(val value: String?, val updated: Instant): PageTitleCache()
+        object NotFound: PageTitleCache()
+    }
+
+    private suspend fun getPageTitleFromCache(url: String): PageTitleCache {
+        val value = cacheLock.withLock {
+            cache[url] ?: return PageTitleCache.NotFound
+        }
+
+        // クエリパラメータがあるときはキャッシュを無視
+        val parsedUrl = Url(url)
+        if (!parsedUrl.parameters.isEmpty()) {
+            return PageTitleCache.NotFound
+        }
+
+        // キャッシュ期限が切れたものは無視
+        val delta = java.time.Duration.between(Instant.now(), value.updated)
+        return if (delta < cacheValidDuration) {
+            value
+        } else {
+            PageTitleCache.NotFound
+        }
+    }
+
+    private suspend fun setPageTitleToCache(url: String, title: String?) {
+        cacheLock.withLock {
+            cache[url] = PageTitleCache.Value(title, Instant.now())
+        }
     }
 }


### PR DESCRIPTION
+ URLが20個並んだブログ記事を更新できるようにするためにはどうすればいいか考えて実装してください。  
  + `fetcher` サービスにページタイトルのキャッシュ機能を追加した。 (https://github.com/SlashNephy/Hatena-Intern-2020/commit/5fc864e72fce6fc780d47383419c700685b3f8e0)
    + 一定時間 (3時間) 以内に取得されたページタイトルはキャッシュから返却される。
    + クエリ文字列 (`?`) を含む URL はキャッシュの対象外とした。
    + MySQL を使ってキャッシュを半永続化することも考えたが, 今回はメモリ上だけのキャッシュとして実装しました。

  + `renderer-ts` の URL の更新処理を改善した。 (https://github.com/SlashNephy/Hatena-Intern-2020/commit/b6261b0d00559e1826b4a90313163c6b316f7c1c)
    + 直列に `FetchService.getPageTitle()` を実行していたが, `Promise.all()` を使って並列化することにした。

+ 100個、あるいは500個URLがあるときはどうすればいいでしょうか。  
+ 一般に外部のウェブサイトへリクエストを行うサービスを設計する際に注意すべきことを考えましょう。  ウェブサイト運営者の立場に立って、困ることを考えましょう。  

1問目の詳細と上記 2問 の解答は以下の `answer.md` にあります。  
https://github.com/SlashNephy/Hatena-Intern-2020/blob/advanced/answer.md